### PR TITLE
Permissions added for binaries (important for new vm's), cleanup updated, readme updated

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,11 +9,12 @@ This playbook is designed to create a data folder for internal registry at the r
 # Before Running the playbook
 0. Access: https://console.redhat.com/openshift/install/pull-secret and download a pull-secret.json file to `/tmp/pull-secret.json`
    
-   if the login automation not worknig, please login manually
+   Also do the next command and enter your credentials:
    sudo podman login registry.redhat.io
  
 
 1. Make sure you have enough space available on the disk (more than 50GB)
+   *** If you use partitions make sure /var have at least 5GB and other memory is at /
 
 2. Run:
 ```bash

--- a/playbook.yaml
+++ b/playbook.yaml
@@ -6,7 +6,7 @@
     scrptfile: "{{ playbook_dir }}/scripts" 
     regsfile:  "{{ playbook_dir }}/regs"
     regone: "localregistry"
-    ocpver:  "v4.8"
+    ocpver:  "v4.9"
     rhindex: "registry.redhat.io" 
   
   tasks:

--- a/roles/cleanup/tasks/clean-up.yaml
+++ b/roles/cleanup/tasks/clean-up.yaml
@@ -12,7 +12,19 @@
   file:
     state: absent
     path: "{{ destfile  }}"
-    
+
+- name: Delete {{ extfile }} dir
+  file:
+    state: absent
+    path: "{{ extfile }}/{{ item }}"
+  loop:
+    - oc
+    - opm
+    - kubectl
+    - grpcurl
+    - README.md
+    - LICENSE
+    - packages.out
 
 - name: Delete {{ regone }} container
   containers.podman.podman_container:

--- a/roles/opm-get-images/tasks/grpcurl-operator.yaml
+++ b/roles/opm-get-images/tasks/grpcurl-operator.yaml
@@ -9,7 +9,7 @@
 - name: run opm index on podman 
   shell: podman run -p50051:50051 -d -it registry.redhat.io/redhat/{{ rhuserindex.user_input }}:{{ ocpver }}
 
-- name: grep the indext --> operators names to packages.out file
+- name: grep the index --> operators names to packages.out file
   shell: grpcurl -plaintext localhost:50051 api.Registry/ListPackages >{{ extfile }}/packages.out
 
 

--- a/roles/prerequisites/tasks/install-check-prereq.yaml
+++ b/roles/prerequisites/tasks/install-check-prereq.yaml
@@ -76,6 +76,7 @@
   copy:
     src: "{{ extfile }}/{{ item  }}"
     dest: /usr/local/bin
+    mode: 0777
   become: yes
   with_items:
     - opm
@@ -87,6 +88,7 @@
   copy:
     src: "{{ extfile }}/{{ item  }}"
     dest: /usr/local/sbin
+    mode: 0777
   become: yes
   with_items:
     - opm
@@ -94,10 +96,11 @@
     - kubectl
     - grpcurl
 
-- name: cpoy grpcurl to /usr/bin
+- name: copy grpcurl to /usr/bin
   copy:
     src: "{{ extfile }}/{{ item }}"
     dest: /usr/bin
+    mode: 0777
   become: yes
   with_items:
     - opm


### PR DESCRIPTION
Added permissions for downloaded binaries (oc, opm, kubectl, grpcurl):
very important for running those binaries on new machines because the usage of them is not done by root (become: yes)

readme updated with tips for new vm machine partitioning
another thing is that it is needed to both podman login and also get the /tmp/pull-secret.json

cleanup updated for organization of the extfile folder absenting